### PR TITLE
修复JSONObject中对不存在的key调用getJSONArray抛异常问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
             <version>2.11.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/jackson/replaces/fastjson/JSONObject.java
+++ b/src/main/java/jackson/replaces/fastjson/JSONObject.java
@@ -51,6 +51,10 @@ public class JSONObject extends JSON implements Map<String, Object> {
     public JSONArray getJSONArray(String key) {
         Object value = map.get(key);
 
+        if (value == null) {
+            return null;
+        }
+
         if (value instanceof JSONArray) {
             return (JSONArray) value;
         }

--- a/src/test/java/replaces/DataTest.java
+++ b/src/test/java/replaces/DataTest.java
@@ -3,8 +3,25 @@ package replaces;
 import jackson.replaces.fastjson.JSON;
 import jackson.replaces.fastjson.JSONArray;
 import jackson.replaces.fastjson.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class Test {
+public class DataTest {
+
+    @Test
+    public void testParseInnerArray() {
+        String data = "{\n" +
+                "  \"key\": \"value\"\n" +
+                "}";
+        JSONObject json = JSON.parseObject(data);
+        try {
+            JSONArray shouldBeNull = json.getJSONArray("somekeynotexists");
+            Assertions.assertNull(shouldBeNull);
+        } catch (Exception e) {
+            Assertions.fail();
+        }
+    }
+
     public static void main(String[] args) {
         String a = "[\n" +
                 "    {\n" +


### PR DESCRIPTION
修复JSONObject中对不存在的key调用getJSONArray抛异常问题
这里主要考虑和fastjson的用法习惯保持一致，避免异常影响原有代码逻辑。
测试代码如下
```
//language=JSON
        String test = "{\"haha\": \"heihei\"}";
        JSONObject jsonObject = JSON.parseObject(test);
        JSONArray data = jsonObject.getJSONArray("data");
       // 这里应该返回null，但是实际抛出异常了
        if (data == null) {
            System.out.println("null");
        }

        jackson.replaces.fastjson.JSONObject json2 = jackson.replaces.fastjson.JSON.parseObject(test);
        jackson.replaces.fastjson.JSONArray data1 = json2.getJSONArray("data");
        if (data1 == null) {
            System.out.println("null");
        }
```

另外添加了junit包。
**建议**：
1. 对测试还是规整一些好。
2. 添加自动测试发布机制，让这个库能活起来。


最后，感谢原作者的好代码。